### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "git+https://github.com/klein0r/ioBroker.youtube"
   },
   "engines": {
-    "node": ">=14.5.0"
+    "node": ">=16"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",


### PR DESCRIPTION
adapter-core 3.x.x is known to fail at node 14 and older due to npm 6 not installing peerDependencies. So this adapter requires node 16 or higher.